### PR TITLE
fix: Allow downloading attachments

### DIFF
--- a/src/pyconnectwise/clients/connectwise_client.py
+++ b/src/pyconnectwise/clients/connectwise_client.py
@@ -45,7 +45,7 @@ class ConnectWiseClient(ABC):
         params: RequestParams | None = None,
         headers: dict[str, str] | None = None,
         retry_count: int = 0,
-        stream: bool = False
+        stream: bool = False,
     ) -> Response:
         """
         Make an API request using the specified method, endpoint, data, and parameters.

--- a/src/pyconnectwise/clients/connectwise_client.py
+++ b/src/pyconnectwise/clients/connectwise_client.py
@@ -45,6 +45,7 @@ class ConnectWiseClient(ABC):
         params: RequestParams | None = None,
         headers: dict[str, str] | None = None,
         retry_count: int = 0,
+        stream: bool = False
     ) -> Response:
         """
         Make an API request using the specified method, endpoint, data, and parameters.
@@ -76,6 +77,7 @@ class ConnectWiseClient(ABC):
                 headers=headers,
                 json=data,
                 params=cast(dict[str, Any], params or {}),
+                stream=stream,
             )
         else:
             response = requests.request(
@@ -83,6 +85,7 @@ class ConnectWiseClient(ABC):
                 url,
                 headers=headers,
                 params=cast(dict[str, Any], params or {}),
+                stream=stream,
             )
         if not response.ok:
             with contextlib.suppress(json.JSONDecodeError):

--- a/src/pyconnectwise/endpoints/base/connectwise_endpoint.py
+++ b/src/pyconnectwise/endpoints/base/connectwise_endpoint.py
@@ -115,7 +115,7 @@ class ConnectWiseEndpoint:
         data: RequestData | None = None,
         params: RequestParams | None = None,
         headers: dict[str, str] | None = None,
-        stream: bool = False
+        stream: bool = False,
     ) -> Response:
         """
         Make an API request using the specified method, endpoint, data, and parameters.

--- a/src/pyconnectwise/endpoints/base/connectwise_endpoint.py
+++ b/src/pyconnectwise/endpoints/base/connectwise_endpoint.py
@@ -115,6 +115,7 @@ class ConnectWiseEndpoint:
         data: RequestData | None = None,
         params: RequestParams | None = None,
         headers: dict[str, str] | None = None,
+        stream: bool = False
     ) -> Response:
         """
         Make an API request using the specified method, endpoint, data, and parameters.
@@ -137,7 +138,7 @@ class ConnectWiseEndpoint:
         if endpoint:
             url = self._url_join(url, endpoint)
 
-        return self.client._make_request(method, url, data, params, headers)
+        return self.client._make_request(method, url, data, params, headers, stream)
 
     def _build_url(self, other_endpoint: ConnectWiseEndpoint) -> str:
         if other_endpoint._parent_endpoint is not None:

--- a/src/pyconnectwise/endpoints/manage/SystemDocumentsIdDownloadEndpoint.py
+++ b/src/pyconnectwise/endpoints/manage/SystemDocumentsIdDownloadEndpoint.py
@@ -1,5 +1,6 @@
-from requests import Response
 from typing import TYPE_CHECKING
+
+from requests import Response
 
 from pyconnectwise.endpoints.base.connectwise_endpoint import ConnectWiseEndpoint
 

--- a/src/pyconnectwise/endpoints/manage/SystemDocumentsIdDownloadEndpoint.py
+++ b/src/pyconnectwise/endpoints/manage/SystemDocumentsIdDownloadEndpoint.py
@@ -1,3 +1,4 @@
+from requests import Response
 from typing import TYPE_CHECKING
 
 from pyconnectwise.endpoints.base.connectwise_endpoint import ConnectWiseEndpoint
@@ -9,3 +10,9 @@ if TYPE_CHECKING:
 class SystemDocumentsIdDownloadEndpoint(ConnectWiseEndpoint):
     def __init__(self, client: "ConnectWiseClient", parent_endpoint: ConnectWiseEndpoint = None) -> None:
         ConnectWiseEndpoint.__init__(self, client, "download", parent_endpoint=parent_endpoint)
+
+    def stream(self) -> Response:
+        """
+        Performs a GET request against the /system/documents/{id}/download endpoint and returns the response object, supporting streaming
+        """
+        return super()._make_request("GET", stream=True)


### PR DESCRIPTION
When working on an internal project, I realized we couldn't correctly download attachment files. The `SystemDocumentsIdDownloadEndpoint` doesn't support streaming large file contents. This PR has been tested on our internal automation application, and the changes are replicated here. By using `stream=True`, we enable the user to download a large file without overloading the system memory usage.

This does not use `IGettable.__super__` because that requires a model, and file content may not match an internal model.