### PR TITLE
bugfix: ConfigurationQuestion.answer is now str | none

### DIFF
--- a/src/pyconnectwise/models/manage/__init__.py
+++ b/src/pyconnectwise/models/manage/__init__.py
@@ -770,7 +770,7 @@ class CompanyTypeReference(ActivityReference):
 
 
 class ConfigurationQuestion(ConnectWiseModel):
-    answer: dict[str, Any] | None = None
+    answer: str | None = None
     answer_id: Annotated[int | None, Field(alias="answerId")] = None
     field_type: Annotated[
         Literal[


### PR DESCRIPTION
The Manage/PSA API spec incorrectly has QuestionReference listed as returning a dict (object), when in reality it returns a string. This, expectedly, breaks validation.

Fixes #28 #25 