### PR TITLE
Fix UTC Import error  for Python < 3.11

### DIFF
--- a/src/pyconnectwise/clients/automate_client.py
+++ b/src/pyconnectwise/clients/automate_client.py
@@ -1,5 +1,5 @@
 import typing
-from datetime import UTC, datetime
+from datetime import timezone, datetime
 
 from pyconnectwise.clients.connectwise_client import ConnectWiseClient
 from pyconnectwise.config import Config
@@ -68,7 +68,7 @@ class ConnectWiseAutomateAPIClient(ConnectWiseClient):
         self.automate_url: str = automate_url
         self.username: str = username
         self.password: str = password
-        self.token_expiry_time: datetime = datetime.now(tz=UTC)
+        self.token_expiry_time: datetime = datetime.now(tz=timezone.utc)
 
         if config:
             self.config = config
@@ -246,7 +246,7 @@ class ConnectWiseAutomateAPIClient(ConnectWiseClient):
         return token
 
     def _refresh_access_token_if_necessary(self):  # noqa: ANN202
-        if datetime.now(tz=UTC) > self.token_expiry_time:
+        if datetime.now(tz=timezone.utc) > self.token_expiry_time:
             self.access_token = self._get_access_token()
 
     def _get_headers(self) -> dict[str, str]:


### PR DESCRIPTION
A small change that fixes "ImportError: cannot import name 'UTC' from 'datetime'" as UTC shorthand was added in Python 3.11