### PR TITLE
fix: Allow custom-provided `codebase`

### DIFF
--- a/src/pyconnectwise/clients/manage_client.py
+++ b/src/pyconnectwise/clients/manage_client.py
@@ -74,6 +74,8 @@ class ConnectWiseManageAPIClient(ConnectWiseClient):
                 # we need to except here
                 raise ManageCodebaseError()
             self.codebase: str = codebase_request
+        else:
+            self.codebase: str = codebase
 
     # Initializing endpoints
     @property


### PR DESCRIPTION
This fixes an issue discovered when ConnectWise changed the API from `v2024_1` to `v2025_1`. We tried to provide the `codebase="v2025_1"`, and found that it didn't work. The temporary workaround is `cw_api = ConnectWiseManage() # cw_api.codebase = "v2025_1"`