### PR TITLE
fix: Rate limiting handling

### DIFF
--- a/src/pyconnectwise/clients/connectwise_client.py
+++ b/src/pyconnectwise/clients/connectwise_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import threading
 import warnings
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, cast
@@ -115,6 +116,20 @@ class ConnectWiseClient(ABC):
                 raise MethodNotAllowedException(response)
             if response.status_code == 409:
                 raise ConflictException(response)
+            if response.status_code == 429:
+                # Rate limit exceeded
+                if "Retry-After" in response.headers:
+                    retry_after = int(response.headers["Retry-After"])
+                    warnings.warn(
+                        f"Rate limit exceeded. Retrying after {retry_after} seconds.",
+                        stacklevel=1,
+                    )
+                    # Delay the request for the specified time
+                    threading.Event.wait(retry_after)
+                    if retry_count < self.config.max_retries:
+                        retry_count += 1
+                        return self._make_request(method, url, data, params, headers, retry_count)
+                raise MalformedRequestException(response)
             if response.status_code == 500:
                 # if timeout is mentioned anywhere in the response then we'll retry.
                 # Ideally we'd return immediately on any non-timeout errors (since

--- a/src/pyconnectwise/exceptions.py
+++ b/src/pyconnectwise/exceptions.py
@@ -76,6 +76,11 @@ class ConflictException(ConnectWiseException):
     _error_suggestion = "This resource is possibly in use or conflicts with another record."
 
 
+class TooManyRequestsException(ConnectWiseException):
+    _code_explanation = "Too Many Requests"
+    _error_suggestion = "You have exceeded the rate limit for this resource. Please wait and try again later."
+
+
 class ServerError(ConnectWiseException):
     _code_explanation = "Internal Server Error"
 


### PR DESCRIPTION
I have run into issues where ConnectWise Cloudflare rate limits the API. This PR catches that case, waits the requested amount of time, and then retries the request.